### PR TITLE
Add align to __shell_cmd_start__ prevent filling after label

### DIFF
--- a/piko.lds.S
+++ b/piko.lds.S
@@ -20,6 +20,7 @@ SECTIONS
         PROVIDE(__text_start__ = .);
         *(.text*)
         PROVIDE(__text_end__ = .);
+        . = ALIGN(8);
         PROVIDE(__shell_cmd_start__ = .);
         KEEP(*(.shell_cmd*))
         PROVIDE(__shell_cmd_end__ = .);


### PR DESCRIPTION
This fixed #5