### PR TITLE
Fix serial hang when scheduler work

### DIFF
--- a/drivers/serial/serialchar.c
+++ b/drivers/serial/serialchar.c
@@ -30,8 +30,6 @@ static ssize_t serialchar_read(struct file *file,
     struct serial_info *serial = file->f_private;
 
     while (serial->rx_count < count) {
-        CURRENT_THREAD_INFO(cur_thread);
-        sched_dequeue(cur_thread);
         sched_elect(0);
     }
     if (count == 1)


### PR DESCRIPTION
This is relate to #12. When typing in minishell, user may hang their shell.

The problem cause this is because a re-schedule inside the loop. When `sched_elect`
work, it will hang out. The root cause maybe inside the scheduler, but for now, this patch
will help for user to not hang by the shell.