### PR TITLE
Remove sched_elect in serialchar_callback

### DIFF
--- a/drivers/serial/serialchar.c
+++ b/drivers/serial/serialchar.c
@@ -7,7 +7,6 @@
 static void serialchar_callback(struct serial_info *serial)
 {
     sched_enqueue(serial->owner);
-    sched_elect(0);
 }
 
 static int serialchar_open(struct inode *inode, struct file *file)


### PR DESCRIPTION
DO NOT USE sched_elect inside the irq.

If a context switch is done inside the irq,
it will make v7m-head.S `pop {pc}` to a undefined place,
or not able to `pop {pc}` out.

cc. @yenWu.