### PR TITLE
Makefile: Let clean remove gen files

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,6 +60,10 @@ ifneq "$(wildcard $(CMSIS) )" ""
 endif
 	rm -f $(NAME).map $(NAME).lds
 	rm -f $(NAME).elf $(NAME).bin
+# Remove GEN files
+	rm -f include/kernel/syscalls.h
+	rm -f kernel/syscall.c
+	rm -f fs/version
 
 distclean: clean
 	rm -f kernel/syscall.c include/kernel/syscalls.h fs/version


### PR DESCRIPTION
Current `make clean` won't remove generate files (`syscalls.h`, `syscall.c`, `fs/version`).

This will confuse user when they gen these file failed, and can't build the project up. (please see docs/build.rst)