### PR TITLE
tests: Add --debug option

### DIFF
--- a/tests/__main__.py
+++ b/tests/__main__.py
@@ -6,9 +6,10 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('test', nargs='*')
     parser.add_argument('-v', '--verbose', action='store_true', help='Verbose output')
+    parser.add_argument('--debug', action='store_true', help='Run test and wait for gdb connect')
 
     args = parser.parse_args()
     if args.test:
-        runner.run_test(args.test, args.verbose)
+        runner.run_test(args.test, args.verbose, debug=args.debug)
     else:
         runner.main(args.verbose)

--- a/tests/runner.py
+++ b/tests/runner.py
@@ -37,10 +37,10 @@ def print_header(testname, arch):
     print("time        :  %s\n" % strftime("%c"))
 
 
-def run_single_test(testname, verbose, platform='stm32p103'):
+def run_single_test(testname, verbose, platform='stm32p103', debug=False):
     # platform = os.getenv('PLATFORM', 'qemu')
     cmd = ["make", "TEST=%s" % testname, "PLAT=%s" % platform,
-           "--file", "tests/Makefile", "clean_test", "all", "run"]
+           "--file", "tests/Makefile", "clean_test", "all", "dbg" if debug else "run"]
     res = subprocess.run(cmd, universal_newlines=True, stdout=subprocess.PIPE,
                          stderr=subprocess.STDOUT)
     if verbose:
@@ -53,7 +53,7 @@ def run_single_test(testname, verbose, platform='stm32p103'):
     return 0
 
 
-def run_test(tests, verbose):
+def run_test(tests, verbose, debug=False):
     print_qemu_version()
     print_gcc_version()
     print('Staging %s test' % tests)
@@ -63,7 +63,7 @@ def run_test(tests, verbose):
     t0 = datetime.now()
     for test in tests:
         print_header(test, 'ARMv7M')
-        status = run_single_test(test, verbose)
+        status = run_single_test(test, verbose, debug=debug)
         failed_count += status
         results[test] = 'failed' if status else 'ok'
 


### PR DESCRIPTION
This will let each test case run with "dbg",
so the test case will wait for gdb connect.