### PR TITLE
Fix typo

### DIFF
--- a/include/kernel/bitmap.h
+++ b/include/kernel/bitmap.h
@@ -1,4 +1,4 @@
-#ifndef _LINUX_BITMAP_aAA
+#ifndef _LINUX_BITMAP_H
 #define _LINUX_BITMAP_H
 
 #include "linux/list.h"


### PR DESCRIPTION
There is a typo in bitmap.h at the macro.