### PR TITLE
Add prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 This is `Piko/RT`, a tiny Linux-like real-time operating system kernel, optimized for ARM Cortex-M series microprocessors.
 
+Prerequisites
+-------------
+- [QEMU with an STM32 microcontroller implementation](https://beckus.github.io/qemu_stm32/)
 
 ## Run test suite
 


### PR DESCRIPTION
stm32p103 used in this project is not
a supported machine type in recent version of
qemu-system-arm (local test version : 6.2.0)

I add the link of QEMU with stm32p103
implementation as prerequisites in README.md